### PR TITLE
Fix/terrain pc misalignment

### DIFF
--- a/src/Boundary.cpp
+++ b/src/Boundary.cpp
@@ -88,6 +88,12 @@ void Boundary::set_bounds_to_terrain_pc(Point_set_3& pointCloud, const Polygon_2
     //-- Remove points out of the boundary region
     Boundary::set_bounds_to_buildings_pc(pointCloud, pcBndPoly);
 
+    // check if there are any points left in the terrain
+    if (pointCloud.empty()) {
+        throw city4cfd_error("All terrain points are out of domain bounds! "
+                             "Check if your terrain points are aligned with polygons.");
+    }
+
     std::vector<double> bndHeights;
     geomutils::interpolate_poly_from_pc(bndPoly, bndHeights, pointCloud);
     s_outerBndHeight = geomutils::avg(bndHeights); // Height for buffer (for now) - average of outer pts

--- a/src/Map3d.cpp
+++ b/src/Map3d.cpp
@@ -318,6 +318,12 @@ void Map3d::set_bnd() {
     Boundary::set_bounds_to_terrain_pc(m_pointCloud.get_terrain(),
                                        bndPoly, pcBndPoly, startBufferPoly);
 
+    // check if there are any points left in the terrain
+    if (m_pointCloud.get_terrain().empty()) {
+        throw city4cfd_error("All terrain points are out of domain bounds! "
+                                 "Check if your terrain points are aligned with polygons.");
+    }
+
     // update the terrain DT for interpolation
     m_dt.clear();
     m_dt.insert(m_pointCloud.get_terrain().points().begin(),

--- a/src/Map3d.cpp
+++ b/src/Map3d.cpp
@@ -318,12 +318,6 @@ void Map3d::set_bnd() {
     Boundary::set_bounds_to_terrain_pc(m_pointCloud.get_terrain(),
                                        bndPoly, pcBndPoly, startBufferPoly);
 
-    // check if there are any points left in the terrain
-    if (m_pointCloud.get_terrain().empty()) {
-        throw city4cfd_error("All terrain points are out of domain bounds! "
-                                 "Check if your terrain points are aligned with polygons.");
-    }
-
     // update the terrain DT for interpolation
     m_dt.clear();
     m_dt.insert(m_pointCloud.get_terrain().points().begin(),

--- a/src/PointCloud.cpp
+++ b/src/PointCloud.cpp
@@ -126,7 +126,7 @@ void PointCloud::terrain_points_in_polygon(BuildingsPtr& features) {
         auto poly = f->get_poly().get_cgal_type();
 //        const double offset = 1.; // offset hardcoded
 //        auto offsetPoly = geomutils::offset_polygon_geos(poly, offset);
-        auto& offsetPoly = poly; // temp
+        auto& offsetPoly = poly; // temp until terrain is included in buildings
 
         std::vector<Point_index*> intersected_nodes;
         pointCloudIndex.find_intersections(intersected_nodes, offsetPoly.bbox().xmin(), offsetPoly.bbox().xmax(),


### PR DESCRIPTION
Add a proper error message when the terrain point cloud and domain boundary are misaligned.