### PR TITLE
CGAL 6.2. compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,4 +96,8 @@ target_link_libraries(city4cfd
         ${OpenMP_support}
         )
 
+# CGAL >= 6.2 requires CGAL_LINKED_WITH_LASLIB to be defined to enable CGAL::IO::read_LAS();
+# City4CFD already bundles and links against LASlib, so just flag it as available.
+target_compile_definitions(city4cfd PRIVATE CGAL_LINKED_WITH_LASLIB)
+
 install(TARGETS city4cfd DESTINATION bin)

--- a/src/ReconstructedBuilding.cpp
+++ b/src/ReconstructedBuilding.cpp
@@ -31,6 +31,12 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 #include <CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#if CGAL_VERSION_NR >= 1060201000 // 6.2.0 -- extract_boundary_cycles() moved from PMP:: to CGAL:: namespace,
+                                  // header moved to CGAL/boost/graph/border.h
+#include <CGAL/boost/graph/border.h>
+#else
+#include <CGAL/Polygon_mesh_processing/border.h>
+#endif
 
 ReconstructedBuilding::ReconstructedBuilding()
         : Building(), m_attributeHeight(-global::largnum),
@@ -262,7 +268,11 @@ void ReconstructedBuilding::reconstruct() {
                 // collect boundary halfedges
                 typedef boost::graph_traits<Mesh>::halfedge_descriptor halfedge_descriptor;
                 std::vector<halfedge_descriptor> borderCycles;
+#if CGAL_VERSION_NR >= 1060201000 // 6.2.0
+                CGAL::extract_boundary_cycles(mesh, std::back_inserter(borderCycles));
+#else
                 PMP::extract_boundary_cycles(mesh, std::back_inserter(borderCycles));
+#endif
                 // fill using boundary halfedges
                 for(halfedge_descriptor h : borderCycles) {
                     // don't triangulate the removed bottom in case of remove_bottom

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,7 @@ void printWelcome() {
     };
 
     std::cout << logo;
-    std::cout << "City4CFD Copyright (C) 2021-2025 3D Geoinformation Research Group, TU Delft\n" << std::endl;
+    std::cout << "City4CFD Copyright (C) 2021-2026 3D Geoinformation Research Group, TU Delft\n" << std::endl;
 }
 
 void printHelp() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@
 
 #include  <boost/algorithm/string/predicate.hpp>
 
-std::string CITY4CFD_VERSION = "0.8.0+dev";
+std::string CITY4CFD_VERSION = "0.8.1";
 
 void printWelcome() {
     auto logo{


### PR DESCRIPTION
This PR takes care of a deprecated function which causes macos build with CGAL 6.2 to fail.